### PR TITLE
Optimize rules matching

### DIFF
--- a/src/public_suffix/list.cr
+++ b/src/public_suffix/list.cr
@@ -1,12 +1,13 @@
 module PublicSuffix
-  LIST = parse_dat_file
+  RULES = parse_dat_file
 
-  def self.parse_dat_file : Array(Rule)
+  def self.parse_dat_file : Hash(String, Array(Rule))
     # start_time = Time.monotonic
 
     embedded_dat_file = {{ read_file(__DIR__ + "/../../public_suffix_list.dat") }}
 
-    rules = Array(Rule).new
+    rules = Hash(String, Array(Rule)).new
+
     embedded_dat_file.each_line do |str|
       str = str.gsub(/\s|(?:\/\/).*?$/, "")
       next if str.blank?
@@ -22,16 +23,20 @@ module PublicSuffix
         wildcard = true
       end
 
-      rules << Rule.new(str.split(".").reverse, wildcard, exception)
+      labels = str.split(".").reverse
+
+      rules_for_key = rules.fetch(labels[0], Array(Rule).new)
+      rules_for_key.push(Rule.new(labels, wildcard, exception))
+      rules[labels[0]] = rules_for_key
     end
 
     # puts "Parsed dat file in #{(Time.monotonic - start_time).milliseconds} ms"
-
     rules
   end
 
   # return all matching rules for domain
   def self.find_matching_rules(for domain : Domain)
-    LIST.map { |rule| rule.dup if rule.match(domain) }.compact
+    rules = RULES.fetch(domain.labels[0], [] of Rule)
+    rules.map { |rule| rule.dup if rule.match(domain) }.compact
   end
 end


### PR DESCRIPTION
Instead of iterating over the whole list, we store a hash with key being foremost label and values as array of rules.

This way we need to match only a fraction of rules, making the whole thing 6 times faster.